### PR TITLE
Change order of first two args in msumloglike()

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -215,8 +215,8 @@ like_state <- function(state, p, nests, alpha, cell_nest, min_like = 1e-10) {
 #' 
 #' Calculate the log-likelihood of a trace of states as the sum over states and subject log-likelihoods.
 #'
-#' @param trace List of lists of lists with subject data.
 #' @param p Numeric matrix with subject parameters for each subject.
+#' @param trace List of lists of lists with subject data.
 #' @param nests List of vectors with utility indices.
 #' @param alpha List of vectors with alpha values.
 #' @param cell_nest Numeric matrix with nest indices for each cell.
@@ -225,8 +225,8 @@ like_state <- function(state, p, nests, alpha, cell_nest, min_like = 1e-10) {
 #' 
 #' @returns Numeric scalar trace log-likelihood.
 #' @export
-msumlogLike <- function(trace, p, nests, alpha, cell_nest, min_like = 1e-10, mult = -1.0) {
-    .Call(`_m4ma_msumlogLike`, trace, p, nests, alpha, cell_nest, min_like, mult)
+msumlogLike <- function(p, trace, nests, alpha, cell_nest, min_like = 1e-10, mult = -1.0) {
+    .Call(`_m4ma_msumlogLike`, p, trace, nests, alpha, cell_nest, min_like, mult)
 }
 
 #' Probability of the Conditional Nested Logit Model

--- a/man/msumlogLike.Rd
+++ b/man/msumlogLike.Rd
@@ -4,12 +4,12 @@
 \alias{msumlogLike}
 \title{Trace Log-likelihood}
 \usage{
-msumlogLike(trace, p, nests, alpha, cell_nest, min_like = 1e-10, mult = -1)
+msumlogLike(p, trace, nests, alpha, cell_nest, min_like = 1e-10, mult = -1)
 }
 \arguments{
-\item{trace}{List of lists of lists with subject data.}
-
 \item{p}{Numeric matrix with subject parameters for each subject.}
+
+\item{trace}{List of lists of lists with subject data.}
 
 \item{nests}{List of vectors with utility indices.}
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -203,19 +203,19 @@ BEGIN_RCPP
 END_RCPP
 }
 // msumlogLike
-double msumlogLike(List trace, NumericMatrix p, List nests, List alpha, NumericMatrix cell_nest, double min_like, double mult);
-RcppExport SEXP _m4ma_msumlogLike(SEXP traceSEXP, SEXP pSEXP, SEXP nestsSEXP, SEXP alphaSEXP, SEXP cell_nestSEXP, SEXP min_likeSEXP, SEXP multSEXP) {
+double msumlogLike(NumericMatrix p, List trace, List nests, List alpha, NumericMatrix cell_nest, double min_like, double mult);
+RcppExport SEXP _m4ma_msumlogLike(SEXP pSEXP, SEXP traceSEXP, SEXP nestsSEXP, SEXP alphaSEXP, SEXP cell_nestSEXP, SEXP min_likeSEXP, SEXP multSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< List >::type trace(traceSEXP);
     Rcpp::traits::input_parameter< NumericMatrix >::type p(pSEXP);
+    Rcpp::traits::input_parameter< List >::type trace(traceSEXP);
     Rcpp::traits::input_parameter< List >::type nests(nestsSEXP);
     Rcpp::traits::input_parameter< List >::type alpha(alphaSEXP);
     Rcpp::traits::input_parameter< NumericMatrix >::type cell_nest(cell_nestSEXP);
     Rcpp::traits::input_parameter< double >::type min_like(min_likeSEXP);
     Rcpp::traits::input_parameter< double >::type mult(multSEXP);
-    rcpp_result_gen = Rcpp::wrap(msumlogLike(trace, p, nests, alpha, cell_nest, min_like, mult));
+    rcpp_result_gen = Rcpp::wrap(msumlogLike(p, trace, nests, alpha, cell_nest, min_like, mult));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/likelihood.cpp
+++ b/src/likelihood.cpp
@@ -76,8 +76,8 @@ NumericVector like_state(List state, NumericMatrix p, List nests, List alpha, Nu
 //' 
 //' Calculate the log-likelihood of a trace of states as the sum over states and subject log-likelihoods.
 //'
-//' @param trace List of lists of lists with subject data.
 //' @param p Numeric matrix with subject parameters for each subject.
+//' @param trace List of lists of lists with subject data.
 //' @param nests List of vectors with utility indices.
 //' @param alpha List of vectors with alpha values.
 //' @param cell_nest Numeric matrix with nest indices for each cell.
@@ -87,7 +87,7 @@ NumericVector like_state(List state, NumericMatrix p, List nests, List alpha, Nu
 //' @returns Numeric scalar trace log-likelihood.
 //' @export
 // [[Rcpp::export]]
-double msumlogLike(List trace, NumericMatrix p, List nests, List alpha, NumericMatrix cell_nest, double min_like = 1e-10, double mult = -1.0) {
+double msumlogLike(NumericMatrix p, List trace, List nests, List alpha, NumericMatrix cell_nest, double min_like = 1e-10, double mult = -1.0) {
   int l = trace.length();
   double llike_trace = 0.0;
   

--- a/tests/testthat/test-likelihood.R
+++ b/tests/testthat/test-likelihood.R
@@ -44,6 +44,6 @@ testthat::test_that("State likelihood computation works", {
 })
 
 testthat::test_that("Trace likelihood sum works", {
-  ll_sum = m4ma::msumlogLike(test_trace_rcpp, p, nests, alpha, m4ma::get_cell_nest())
+  ll_sum = m4ma::msumlogLike(p, test_trace_rcpp, nests, alpha, m4ma::get_cell_nest())
   testthat::expect_equal(-ll_sum, ref)
 })


### PR DESCRIPTION
Closes Nlesc-team/Sushi#268

Changes the order of the args in `msumloglike()` function: `p` (the subject parameters matrix) is now in first place, and `trace` (the simulated/observed data), is now second. This change is necessary because the optimizer that the project partners use requires the parameters optimized over to be the first argument of the function.