### PR TITLE
Rename "trace" argument in msumloglike() function

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -216,7 +216,7 @@ like_state <- function(state, p, nests, alpha, cell_nest, min_like = 1e-10) {
 #' Calculate the log-likelihood of a trace of states as the sum over states and subject log-likelihoods.
 #'
 #' @param p Numeric matrix with subject parameters for each subject.
-#' @param trace List of lists of lists with subject data.
+#' @param trace_rcpp List of lists of lists with subject data.
 #' @param nests List of vectors with utility indices.
 #' @param alpha List of vectors with alpha values.
 #' @param cell_nest Numeric matrix with nest indices for each cell.
@@ -225,8 +225,8 @@ like_state <- function(state, p, nests, alpha, cell_nest, min_like = 1e-10) {
 #' 
 #' @returns Numeric scalar trace log-likelihood.
 #' @export
-msumlogLike <- function(p, trace, nests, alpha, cell_nest, min_like = 1e-10, mult = -1.0) {
-    .Call(`_m4ma_msumlogLike`, p, trace, nests, alpha, cell_nest, min_like, mult)
+msumlogLike <- function(p, trace_rcpp, nests, alpha, cell_nest, min_like = 1e-10, mult = -1.0) {
+    .Call(`_m4ma_msumlogLike`, p, trace_rcpp, nests, alpha, cell_nest, min_like, mult)
 }
 
 #' Probability of the Conditional Nested Logit Model

--- a/README.md
+++ b/README.md
@@ -55,9 +55,8 @@ cell_nest = m4ma::get_cell_nest()
 # Transform trace into format for C++ processing
 trace_rcpp = m4ma::create_rcpp_trace(get(trace_name))
 
-
 # Compute log likelihood of trace given subject parameters
-m4ma::msumlogLike(trace_rcpp, p, nests, alpha, cell_nest)
+m4ma::msumlogLike(p, trace_rcpp, nests, alpha, cell_nest)
 
 # 176.7388
 

--- a/man/msumlogLike.Rd
+++ b/man/msumlogLike.Rd
@@ -4,12 +4,20 @@
 \alias{msumlogLike}
 \title{Trace Log-likelihood}
 \usage{
-msumlogLike(p, trace, nests, alpha, cell_nest, min_like = 1e-10, mult = -1)
+msumlogLike(
+  p,
+  trace_rcpp,
+  nests,
+  alpha,
+  cell_nest,
+  min_like = 1e-10,
+  mult = -1
+)
 }
 \arguments{
 \item{p}{Numeric matrix with subject parameters for each subject.}
 
-\item{trace}{List of lists of lists with subject data.}
+\item{trace_rcpp}{List of lists of lists with subject data.}
 
 \item{nests}{List of vectors with utility indices.}
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -203,19 +203,19 @@ BEGIN_RCPP
 END_RCPP
 }
 // msumlogLike
-double msumlogLike(NumericMatrix p, List trace, List nests, List alpha, NumericMatrix cell_nest, double min_like, double mult);
-RcppExport SEXP _m4ma_msumlogLike(SEXP pSEXP, SEXP traceSEXP, SEXP nestsSEXP, SEXP alphaSEXP, SEXP cell_nestSEXP, SEXP min_likeSEXP, SEXP multSEXP) {
+double msumlogLike(NumericMatrix p, List trace_rcpp, List nests, List alpha, NumericMatrix cell_nest, double min_like, double mult);
+RcppExport SEXP _m4ma_msumlogLike(SEXP pSEXP, SEXP trace_rcppSEXP, SEXP nestsSEXP, SEXP alphaSEXP, SEXP cell_nestSEXP, SEXP min_likeSEXP, SEXP multSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< NumericMatrix >::type p(pSEXP);
-    Rcpp::traits::input_parameter< List >::type trace(traceSEXP);
+    Rcpp::traits::input_parameter< List >::type trace_rcpp(trace_rcppSEXP);
     Rcpp::traits::input_parameter< List >::type nests(nestsSEXP);
     Rcpp::traits::input_parameter< List >::type alpha(alphaSEXP);
     Rcpp::traits::input_parameter< NumericMatrix >::type cell_nest(cell_nestSEXP);
     Rcpp::traits::input_parameter< double >::type min_like(min_likeSEXP);
     Rcpp::traits::input_parameter< double >::type mult(multSEXP);
-    rcpp_result_gen = Rcpp::wrap(msumlogLike(p, trace, nests, alpha, cell_nest, min_like, mult));
+    rcpp_result_gen = Rcpp::wrap(msumlogLike(p, trace_rcpp, nests, alpha, cell_nest, min_like, mult));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/likelihood.cpp
+++ b/src/likelihood.cpp
@@ -77,7 +77,7 @@ NumericVector like_state(List state, NumericMatrix p, List nests, List alpha, Nu
 //' Calculate the log-likelihood of a trace of states as the sum over states and subject log-likelihoods.
 //'
 //' @param p Numeric matrix with subject parameters for each subject.
-//' @param trace List of lists of lists with subject data.
+//' @param trace_rcpp List of lists of lists with subject data.
 //' @param nests List of vectors with utility indices.
 //' @param alpha List of vectors with alpha values.
 //' @param cell_nest Numeric matrix with nest indices for each cell.
@@ -87,12 +87,12 @@ NumericVector like_state(List state, NumericMatrix p, List nests, List alpha, Nu
 //' @returns Numeric scalar trace log-likelihood.
 //' @export
 // [[Rcpp::export]]
-double msumlogLike(NumericMatrix p, List trace, List nests, List alpha, NumericMatrix cell_nest, double min_like = 1e-10, double mult = -1.0) {
-  int l = trace.length();
+double msumlogLike(NumericMatrix p, List trace_rcpp, List nests, List alpha, NumericMatrix cell_nest, double min_like = 1e-10, double mult = -1.0) {
+  int l = trace_rcpp.length();
   double llike_trace = 0.0;
   
   for(int i = 0;  i < l; ++i) {
-    List state_i = trace[i];
+    List state_i = trace_rcpp[i];
     llike_trace += sum(like_state(state_i, p, nests, alpha, cell_nest, min_like));
   }
   


### PR DESCRIPTION
The optimizer JDEoptim has its own argument called `trace`, which creates a conflict with the `trace` argument in the function `msumloglike()`. To resolve the conflict, this PR changes the name of the argument to `trace_rcpp`. The name is also supposed to indicate that the function needs to receive the trace in a different format than the original function (as returned by `create_rcpp_trace()`).

Also updates the README to account for the changes in the `msumloglike()` argument order (`p` and `trace_rcpp` switched).