### PR TITLE
Fix bugs in getLeaders C++ function

### DIFF
--- a/R/utility_extra_wrappers.R
+++ b/R/utility_extra_wrappers.R
@@ -43,6 +43,14 @@ getLeaders = wrapper('getLeaders')
 
 
 #' @rdname getBuddy_rcpp
-#' @param ... Arguments passed to the function implementation.
 #' @param use Whether the R or C++ implementation is called.
-getBuddy = wrapper('getBuddy')
+getBuddy = function(n, group, a, p_pred, centres, objects, pickBest = FALSE, 
+                    state, use = 'cpp') {
+  if (use == 'r' || (exists('predped_env') && predped_env$use == 'r')) {
+    return(m4ma::getBuddy_r(n, group, a, p_pred, centres, objects,
+                            pickBest, state))
+  } else {
+    return(m4ma::getBuddy_rcpp(n, group, a, p_pred, centres, objects,
+                               pickBest, state))
+  }
+}

--- a/man/getBuddy_rcpp.Rd
+++ b/man/getBuddy_rcpp.Rd
@@ -11,7 +11,17 @@ getBuddy_rcpp(n, group, a, p_pred, centres, objects, pickBest, state)
 
 getBuddy_r(n, group, a, p_pred, centres, objects, pickBest = FALSE, state)
 
-getBuddy(..., use = "cpp")
+getBuddy(
+  n,
+  group,
+  a,
+  p_pred,
+  centres,
+  objects,
+  pickBest = FALSE,
+  state,
+  use = "cpp"
+)
 }
 \arguments{
 \item{n}{Integer scalar index of current pedestrian in pedestrian matrix.}
@@ -32,8 +42,6 @@ two length-two numeric vectors of x- and y-coordinates.}
 returned.}
 
 \item{state}{List with state data.}
-
-\item{...}{Arguments passed to the function implementation.}
 
 \item{use}{Whether the R or C++ implementation is called.}
 }

--- a/src/utility_extra.cpp
+++ b/src/utility_extra.cpp
@@ -682,10 +682,12 @@ Nullable<List> getLeaders_rcpp(
       return(R_NilValue);
     } else {
       candidates = candidates[inGroup];
+      candidates_names = candidates_names[inGroup];
     } 
   // if leaders are preferred from in-group
   } else if (preferGroup && is_true(any(inGroup))) {
     candidates = candidates[inGroup];
+    candidates_names = candidates_names[inGroup];
   }
   
   // get candidate angles
@@ -709,8 +711,8 @@ Nullable<List> getLeaders_rcpp(
   }
   
   candidates = candidates[ok];
+  candidates_names = candidates_names[ok];
   angles = angles[ok];
-  
   NumericVector leaders;
   CharacterVector leaders_names;
   if(is_false(any(duplicated(candidates)))) {
@@ -718,7 +720,7 @@ Nullable<List> getLeaders_rcpp(
     leaders_names = candidates_names;
   } else {
     leaders = unique(candidates);
-    leaders_names = unique(candidates_names);
+    leaders_names = rep("", leaders.length());
     for(int i = 0; i < leaders.length(); i++) {
       double leaders_i = leaders[i];
       NumericVector leaders_angles_i = angles[candidates == leaders_i];


### PR DESCRIPTION
Closes Nlesc-team/Sushi#327

Fixes two bugs:
1. In the `getLeaders()` wrapper, a default argument for `pickBest` (is `TRUE` in the R version) was missing, which required a customized wrapper function instead of a generated one.
2. In `getLeaders_rcpp()`, a bug occured when leader candidates were discarded (e.g., because they were duplicate or not from the same group) and the candidate names vector did not match the candidate vector anymore. I added a few lines that update the candidate names vector or recreate it (this is necessary for duplicate candidates)