### PR TITLE
Fix output name bug in Dn() C++ function

### DIFF
--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -273,9 +273,9 @@ NumericVector Dn_rcpp(NumericMatrix p_n, NumericMatrix P_n){
   }
   
   // assign row names of p2 if they exist 
-  if(rownames(p_n) != R_NilValue) {
-    out.names() = rownames(p_n);
-  }
+  // if(rownames(p_n) != R_NilValue) {
+  //   out.names() = rownames(p_n);
+  // }
   
   return(out);
   

--- a/tests/testthat/test-geometry.R
+++ b/tests/testthat/test-geometry.R
@@ -73,7 +73,7 @@ testthat::test_that("Iangle geometry function works", {
 testthat::test_that("Dn geometry function works", {
   ref = m4ma::Dn_r(p_n = p1, P_n = p2) 
   res = m4ma::Dn_rcpp(p_n = p1, P_n = p2)
-  testthat::expect_equal(unname(res), ref)
+  testthat::expect_equal(res, ref)
 })
 
 testthat::test_that("minAngle geometry function works", {


### PR DESCRIPTION
Closes Nlesc-team/Sushi#326

Fixes a small bug in the `Dn()` C++ function, where the names of the output vector did not match the name of the R output. Previously, this didn't seem to be a problem, however, when only using this C++ implementation in the simulation, it causes an error.