### PR TITLE
Change subject indexing in subject likelihood estimation

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -56,7 +56,7 @@ create_rcpp_trace = function(trace, elements = "iterations") {
             BA = state$BA[[n]],
             FL = state$FL[[n]],
             WB = state$WB[[n]],
-            n = n - 1
+            n = n
           )
         } else {
           rcpp_state = NULL

--- a/src/likelihood.cpp
+++ b/src/likelihood.cpp
@@ -89,10 +89,11 @@ NumericVector like_state(
       n = i;
     } else {
       n = state_i["n"];
+      n = n - 1; // c++ indexing
     }
     NumericVector p_n = p(n, _);
     p_n.names() = colnames(p);
-    llike_state[i] = like_observation(state_i, p_n, n, nests, alpha, cell_nest, min_like);
+    llike_state[i] = like_observation(state_i, p_n, n - 1, nests, alpha, cell_nest, min_like); 
   }
   
   return llike_state;


### PR DESCRIPTION
The change to 0-indexing for the subject index is now performed in the `like_state()` function instead of the `create_rcpp_states()` helper function.