### PR TITLE
Bug fix: Divide by sSlow (see RCore predped)

### DIFF
--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -197,7 +197,7 @@ NumericVector psUtility_rcpp(double aPS, double bPS, double sPref, double sSlow,
                              double v, double d) {
   
   // take the parallel min of sPref
-  double sPref2 = std::min(sPref, sPref * (d / v * sSlow));	
+  double sPref2 = std::min(sPref, sPref * (d / (v * sSlow)));	
   
   // compute utility for different rings
   NumericVector rings = NumericVector::create(1.5, 1.0, 0.5); // !


### PR DESCRIPTION
Contains a small bug fix that was noticed and tested in the predped package. 